### PR TITLE
Style, lint, more throttling, more logging, more options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 venv
 *.sw*
+*.env
 __pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
-FROM python:3.8-alpine
-
+FROM python:3.8-alpine AS base
 WORKDIR /app
-
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+FROM base AS lint
+RUN pip install --no-cache-dir pylint
 COPY *.py ./
+WORKDIR /
+CMD ["pylint", "app"]
 
+FROM base AS prod
+COPY *.py ./
 WORKDIR /
 CMD ["python", "-m", "app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM alpine:latest
+FROM python:3.8-alpine
 
-RUN apk update && apk add python3 && mkdir -p /opt/amazon-mws-analytics
-COPY . /opt/amazon-mws-analytics
+WORKDIR /app
 
-WORKDIR /opt
-RUN cd /opt/amazon-mws-analytics && pip3 install -r requirements.txt
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
 
-ENTRYPOINT python3 -m amazon-mws-analytics
+COPY *.py ./
+
+WORKDIR /
+CMD ["python", "-m", "app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,13 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-FROM base AS lint
-RUN pip install --no-cache-dir pylint
-COPY *.py ./
+FROM base AS dev
+# Alas, black depends on regex, which doesn't have an Alpine wheel, which means
+# we need to compile it, which means we need a build environment.
+RUN apk add --no-cache --virtual .black-build-deps gcc musl-dev \
+   && pip install --prefer-binary --no-cache-dir pylint black \
+   && apk del --no-cache .black-build-deps
 WORKDIR /
-CMD ["pylint", "app"]
 
 FROM base AS prod
 COPY *.py ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM base AS dev
 # Alas, black depends on regex, which doesn't have an Alpine wheel, which means
 # we need to compile it, which means we need a build environment.
 RUN apk add --no-cache --virtual .black-build-deps gcc musl-dev \
-   && pip install --prefer-binary --no-cache-dir pylint black \
+   && pip install --prefer-binary --no-cache-dir pylint black isort \
    && apk del --no-cache .black-build-deps
 WORKDIR /
 

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,10 @@ build:
 
 .PHONY: style
 style:
-	docker run -it --rm -v "$(PWD)":/code jbbarth/black *.py
+	docker build --target dev -t $(REPO):dev .
+	docker run --rm -it -v "$(PWD)":/app $(REPO):dev black app
 
 .PHONY: lint
 lint:
-	docker build --target lint -t $(REPO):lint .
-	docker run --rm -it $(REPO):lint
+	docker build --target dev -t $(REPO):dev .
+	docker run --rm -it -v "$(PWD)":/app $(REPO):dev pylint app

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+REPO=amazon-mws-analytics
+
+.PHONY: build
+build:
+	docker build -t $(REPO):latest .
+
+.PHONY: style
+style:
+	docker run -it --rm -v "$(PWD)":/code jbbarth/black *.py
+
+.PHONY: lint
+lint:
+	docker run --rm -it -v "$(PWD)":/data cytopia/pylint *.py

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ REPO=amazon-mws-analytics
 
 .PHONY: build
 build:
-	docker build -t $(REPO):latest .
+	docker build --target prod -t $(REPO):latest .
 
 .PHONY: style
 style:
@@ -10,4 +10,5 @@ style:
 
 .PHONY: lint
 lint:
-	docker run --rm -it -v "$(PWD)":/data cytopia/pylint *.py
+	docker build --target lint -t $(REPO):lint .
+	docker run --rm -it $(REPO):lint

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ build:
 .PHONY: style
 style:
 	docker build --target dev -t $(REPO):dev .
+	docker run --rm -it -v "$(PWD)":/app $(REPO):dev isort app
 	docker run --rm -it -v "$(PWD)":/app $(REPO):dev black app
 
 .PHONY: lint

--- a/__main__.py
+++ b/__main__.py
@@ -1,11 +1,12 @@
 import os
+import time
 from datetime import datetime, timedelta
+from functools import partial
 
 from mws import mws
-from functools import partial
-from pymongo import MongoClient, ReplaceOne
+from pymongo import MongoClient
 
-from .orders import get_order_items, orders_generator, set_document_id
+from .orders import set_order_items, orders_generator, set_document_id
 from .utils import make_ratelimit_aware
 
 marketplaceids = os.environ["MARKETPLACEIDS"].split(",")
@@ -18,29 +19,44 @@ orders_api = mws.Orders(
 )
 
 start_date = datetime.now() - timedelta(days=days_ago)
-get_us_orders_from_start_date = partial(
+get_orders_from_start_date = partial(
     orders_api.list_orders,
     marketplaceids=marketplaceids,
     lastupdatedafter=start_date.isoformat(),
 )
-retry_minute_after_ratelimit = partial(make_ratelimit_aware, mws.MWSError, 60)
 
-# Get all orders from Amazon
-orders = orders_generator(
-    retry_minute_after_ratelimit(get_us_orders_from_start_date),
-    retry_minute_after_ratelimit(orders_api.list_orders_by_next_token),
+retry_after_error = partial(make_ratelimit_aware, mws.MWSError)
+
+# ListOrders has max quota 6 and restore rate 1 per 60s. We spend most of our
+# time fetching items, so we can rely on waiting for those to restore the pool.
+# In the event that we hit the limit, we wait 180s to restore half the pool
+# (but this is quite unlikely, and should really only happen if some other task
+# is hitting the API at the same time).
+orders_itr = orders_generator(
+    retry_after_error(get_orders_from_start_date, 180),
+    retry_after_error(orders_api.list_orders_by_next_token, 180),
 )
 
-# Create function to get order_items for each order
+# ListOrderItems has max quota 30 and restore rate 1 per 2s. We aim to slowly
+# wear down the quota and, in the event that we hit the limit, we wait 60s to
+# restore the full pool.
 add_order_items = partial(
-    get_order_items,
-    retry_minute_after_ratelimit(orders_api.list_order_items),
-    retry_minute_after_ratelimit(orders_api.list_order_items_by_next_token),
+    set_order_items,
+    retry_after_error(orders_api.list_order_items, 60),
+    retry_after_error(orders_api.list_order_items_by_next_token, 60),
 )
 
-orders = map(set_document_id, map(add_order_items, orders))
+orders_with_items = []
+for i, order in enumerate(orders_itr):
+    if i > 0:
+        time.sleep(1.5)
+    add_order_items(order)
+    set_document_id(order)
+    orders_with_items.append(order)
 
 mongo = MongoClient(os.environ["MONGODB_URI"])
 upsert_order = partial(mongo.warehouse.amazon_orders.replace_one, upsert=True)
-for order in orders:
+for order in orders_with_items:
+    print(f"Upserting {order['_id']}...", end=" ")
     upsert_order({"_id": order["_id"]}, order)
+    print("done")

--- a/__main__.py
+++ b/__main__.py
@@ -8,33 +8,39 @@ from pymongo import MongoClient, ReplaceOne
 from .orders import get_order_items, orders_generator, set_document_id
 from .utils import make_ratelimit_aware
 
-marketplaceids = os.environ['MARKETPLACEIDS'].split(",")
-days_ago = 1 if 'DAYS_AGO' not in os.environ else int(os.environ['DAYS_AGO'])
-orders_api = mws.Orders(os.environ['AWS_ACCESS_KEY'],
-                        os.environ['MWS_SECRET_KEY'],
-                        os.environ['MWS_SELLERID'],
-                        region=os.environ['REGION'])
+marketplaceids = os.environ["MARKETPLACEIDS"].split(",")
+days_ago = 1 if "DAYS_AGO" not in os.environ else int(os.environ["DAYS_AGO"])
+orders_api = mws.Orders(
+    os.environ["AWS_ACCESS_KEY"],
+    os.environ["MWS_SECRET_KEY"],
+    os.environ["MWS_SELLERID"],
+    region=os.environ["REGION"],
+)
 
 start_date = datetime.now() - timedelta(days=days_ago)
-get_us_orders_from_start_date = partial(orders_api.list_orders,
-                                    marketplaceids=marketplaceids,
-                                    lastupdatedafter=start_date.isoformat())
+get_us_orders_from_start_date = partial(
+    orders_api.list_orders,
+    marketplaceids=marketplaceids,
+    lastupdatedafter=start_date.isoformat(),
+)
 retry_minute_after_ratelimit = partial(make_ratelimit_aware, mws.MWSError, 60)
 
 # Get all orders from Amazon
 orders = orders_generator(
     retry_minute_after_ratelimit(get_us_orders_from_start_date),
-    retry_minute_after_ratelimit(orders_api.list_orders_by_next_token))
+    retry_minute_after_ratelimit(orders_api.list_orders_by_next_token),
+)
 
 # Create function to get order_items for each order
 add_order_items = partial(
     get_order_items,
     retry_minute_after_ratelimit(orders_api.list_order_items),
-    retry_minute_after_ratelimit(orders_api.list_order_items_by_next_token))
+    retry_minute_after_ratelimit(orders_api.list_order_items_by_next_token),
+)
 
 orders = map(set_document_id, map(add_order_items, orders))
 
-mongo = MongoClient(os.environ['MONGODB_URI'])
+mongo = MongoClient(os.environ["MONGODB_URI"])
 upsert_order = partial(mongo.warehouse.amazon_orders.replace_one, upsert=True)
 for order in orders:
-    upsert_order({"_id": order['_id']}, order)
+    upsert_order({"_id": order["_id"]}, order)

--- a/__main__.py
+++ b/__main__.py
@@ -29,6 +29,7 @@ orders_api = mws.Orders(
 )
 
 start_date = datetime.now() - timedelta(days=DAYS_AGO)
+
 get_orders_from_start_date = partial(
     orders_api.list_orders,
     marketplaceids=MARKETPLACEIDS,
@@ -53,7 +54,7 @@ orders_itr = generate_orders(
 set_order_items_with_retry = partial(
     set_order_items,
     retry_after_error(orders_api.list_order_items, 60),
-    retry_after_error(orders_api.list_order_items_by_next_token, 60),
+    retry_after_error(lambda t: orders_api.list_order_items(next_token=t), 60),
 )
 
 orders_with_items = []

--- a/__main__.py
+++ b/__main__.py
@@ -36,7 +36,7 @@ if "START_DATE" in os.environ:
         END_DATE = iso8601.parse_date(os.environ["END_DATE"]).isoformat()
 else:
     DAYS_AGO = 1 if "DAYS_AGO" not in os.environ else int(os.environ["DAYS_AGO"])
-    START_DATE = datetime.now() - timedelta(days=DAYS_AGO).isoformat()
+    START_DATE = (datetime.now() - timedelta(days=DAYS_AGO)).isoformat()
 
 display_end_date = END_DATE if END_DATE is not None else "now"
 print(f"Fetching orders between {START_DATE} and {display_end_date}")

--- a/__main__.py
+++ b/__main__.py
@@ -16,7 +16,7 @@ import iso8601
 from mws import mws
 from pymongo import MongoClient
 
-from .orders import set_order_items, generate_orders
+from .orders import generate_orders, set_order_items
 from .utils import make_ratelimit_aware
 
 orders_api = mws.Orders(

--- a/__main__.py
+++ b/__main__.py
@@ -48,9 +48,9 @@ orders_itr = generate_orders(
     retry_after_error(orders_api.list_orders_by_next_token, 180),
 )
 
-# ListOrderItems has max quota 30 and restore rate 1 per 2s. We aim to slowly
-# wear down the quota and, in the event that we hit the limit, we wait 60s to
-# restore the full pool.
+# ListOrderItems has max quota 30 and restore rate 1 per 2s. We aim to only
+# very slowly wear down the quota and, in the event that we hit the limit, we
+# wait 60s to restore the full pool.
 set_order_items_with_retry = partial(
     set_order_items,
     retry_after_error(orders_api.list_order_items, 60),
@@ -60,7 +60,7 @@ set_order_items_with_retry = partial(
 orders_with_items = []
 for i, order in enumerate(orders_itr):
     if i > 0:
-        time.sleep(1.5)
+        time.sleep(1.75)
     order["_id"] = order["AmazonOrderId"]
     set_order_items_with_retry(order)
     orders_with_items.append(order)

--- a/__main__.py
+++ b/__main__.py
@@ -9,8 +9,9 @@ from pymongo import MongoClient
 from .orders import set_order_items, orders_generator, set_document_id
 from .utils import make_ratelimit_aware
 
-marketplaceids = os.environ["MARKETPLACEIDS"].split(",")
-days_ago = 1 if "DAYS_AGO" not in os.environ else int(os.environ["DAYS_AGO"])
+MARKETPLACEIDS = os.environ["MARKETPLACEIDS"].split(",")
+DAYS_AGO = 1 if "DAYS_AGO" not in os.environ else int(os.environ["DAYS_AGO"])
+
 orders_api = mws.Orders(
     os.environ["AWS_ACCESS_KEY"],
     os.environ["MWS_SECRET_KEY"],
@@ -18,10 +19,10 @@ orders_api = mws.Orders(
     region=os.environ["REGION"],
 )
 
-start_date = datetime.now() - timedelta(days=days_ago)
+start_date = datetime.now() - timedelta(days=DAYS_AGO)
 get_orders_from_start_date = partial(
     orders_api.list_orders,
-    marketplaceids=marketplaceids,
+    marketplaceids=MARKETPLACEIDS,
     lastupdatedafter=start_date.isoformat(),
 )
 

--- a/orders.py
+++ b/orders.py
@@ -39,7 +39,9 @@ def set_order_items(item_getter, item_next_getter, order):
     """Set the "OrderItems" key of an Order dict with the items associated with
     that order.
     """
-    print(f"Listing items for order {order['AmazonOrderId']}...", end=" ")
+    orderid = order["AmazonOrderId"]
+    last_updated = order["LastUpdateDate"].isoformat(timespec="seconds")
+    print(f"Listing items for order {orderid} ({last_updated})...", end=" ")
     items_res = item_getter(order["AmazonOrderId"]).parsed
     flattened_res = _flatten_items(items_res)
     items = flattened_res["OrderItems"]["OrderItem"]

--- a/orders.py
+++ b/orders.py
@@ -1,43 +1,54 @@
-# This is for orders functions
 from .utils import flatten
 
 
 def orders_generator(orders_getter, orders_next_getter):
     """Returns a generator for all orders"""
-    orders_res = orders_getter()
-    flattened_res = flatten(orders_res.parsed)
+    print("Listing orders...", end=" ")
+    orders_res = orders_getter().parsed
 
-    if "Order" not in flattened_res["Orders"]:
+    if "Order" not in orders_res["Orders"]:
+        print("no orders")
         return
 
-    yield from flattened_res["Orders"]["Order"]
+    flattened_res = flatten_orders(orders_res)
+    orders = flattened_res["Orders"]["Order"]
+    print(f"{len(orders)} orders")
+    yield from orders
 
     while "NextToken" in flattened_res:
-        orders_res = orders_next_getter(flattened_res["NextToken"])
-        flattened_res = flatten(orders_res.parsed)
+        print("Listing more orders by NextToken...", end=" ")
+        orders_res = orders_next_getter(flattened_res["NextToken"]).parsed
+        flattened_res = flatten_orders(orders_res)
+        orders = flattened_res["Orders"]["Order"]
+        print(f"{len(orders)} orders")
+        yield from orders
 
-        yield from flattened_res["Orders"]["Order"]
+
+def flatten_orders(orders_res):
+    orders = orders_res["Orders"]["Order"]
+    # If there's only one order, it is serialized as a dict.
+    if not isinstance(orders, list):
+        orders = [orders]
+    orders_res["Orders"]["Order"] = orders
+    return flatten(orders_res)
 
 
-def get_order_items(item_getter, item_next_getter, order):
-    items = item_getter(order["AmazonOrderId"])
+def set_order_items(item_getter, item_next_getter, order):
+    print(f"Listing items for order {order['AmazonOrderId']}...", end=" ")
+    items_res = item_getter(order["AmazonOrderId"]).parsed
     # TODO: Need to implement nextToken for orders with a shit ton of items
+    flattened_items = flatten_items(items_res)
+    print(f"{len(flattened_items)} items")
+    order["OrderItems"] = flattened_items
 
-    clean_items = lambda item: flatten(process_order_items(item))
-    order["OrderItems"] = clean_items(items)
-    return order
 
-
-def process_order_items(items):
-    items = items.parsed["OrderItems"]["OrderItem"]
-
-    # If there's only one item is serialized as a dict.
-    if type(items) is not list:
+def flatten_items(items_res):
+    items = items_res["OrderItems"]["OrderItem"]
+    # If there's only one item, it is serialized as a dict.
+    if not isinstance(items, list):
         items = [items]
-
-    return items
+    return flatten(items)
 
 
 def set_document_id(order):
     order["_id"] = order["AmazonOrderId"]
-    return order

--- a/orders.py
+++ b/orders.py
@@ -1,32 +1,35 @@
 # This is for orders functions
 from .utils import flatten
 
+
 def orders_generator(orders_getter, orders_next_getter):
     """Returns a generator for all orders"""
     orders_res = orders_getter()
     flattened_res = flatten(orders_res.parsed)
 
-    if 'Order' not in flattened_res['Orders']:
+    if "Order" not in flattened_res["Orders"]:
         return
 
-    yield from flattened_res['Orders']['Order']
+    yield from flattened_res["Orders"]["Order"]
 
-    while 'NextToken' in flattened_res:
-        orders_res = orders_next_getter(flattened_res['NextToken'])
+    while "NextToken" in flattened_res:
+        orders_res = orders_next_getter(flattened_res["NextToken"])
         flattened_res = flatten(orders_res.parsed)
 
-        yield from flattened_res['Orders']['Order']
+        yield from flattened_res["Orders"]["Order"]
+
 
 def get_order_items(item_getter, item_next_getter, order):
-    items = item_getter(order['AmazonOrderId'])
+    items = item_getter(order["AmazonOrderId"])
     # TODO: Need to implement nextToken for orders with a shit ton of items
 
     clean_items = lambda item: flatten(process_order_items(item))
-    order['OrderItems'] = clean_items(items)
+    order["OrderItems"] = clean_items(items)
     return order
 
+
 def process_order_items(items):
-    items = items.parsed['OrderItems']['OrderItem']
+    items = items.parsed["OrderItems"]["OrderItem"]
 
     # If there's only one item is serialized as a dict.
     if type(items) is not list:
@@ -34,6 +37,7 @@ def process_order_items(items):
 
     return items
 
+
 def set_document_id(order):
-    order['_id'] = order['AmazonOrderId']
+    order["_id"] = order["AmazonOrderId"]
     return order

--- a/orders.py
+++ b/orders.py
@@ -1,8 +1,10 @@
+"""Fetch and flatten orders and their items."""
+
 from .utils import flatten
 
 
-def orders_generator(orders_getter, orders_next_getter):
-    """Returns a generator for all orders"""
+def generate_orders(orders_getter, orders_next_getter):
+    """Return a stream of orders."""
     print("Listing orders...", end=" ")
     orders_res = orders_getter().parsed
 
@@ -10,7 +12,7 @@ def orders_generator(orders_getter, orders_next_getter):
         print("no orders")
         return
 
-    flattened_res = flatten_orders(orders_res)
+    flattened_res = _flatten_orders(orders_res)
     orders = flattened_res["Orders"]["Order"]
     print(f"{len(orders)} orders")
     yield from orders
@@ -18,13 +20,13 @@ def orders_generator(orders_getter, orders_next_getter):
     while "NextToken" in flattened_res:
         print("Listing more orders by NextToken...", end=" ")
         orders_res = orders_next_getter(flattened_res["NextToken"]).parsed
-        flattened_res = flatten_orders(orders_res)
+        flattened_res = _flatten_orders(orders_res)
         orders = flattened_res["Orders"]["Order"]
         print(f"{len(orders)} orders")
         yield from orders
 
 
-def flatten_orders(orders_res):
+def _flatten_orders(orders_res):
     orders = orders_res["Orders"]["Order"]
     # If there's only one order, it is serialized as a dict.
     if not isinstance(orders, list):
@@ -34,21 +36,20 @@ def flatten_orders(orders_res):
 
 
 def set_order_items(item_getter, item_next_getter, order):
+    """Set the "OrderItems" key of an Order dict with the items associated with
+    that order.
+    """
     print(f"Listing items for order {order['AmazonOrderId']}...", end=" ")
     items_res = item_getter(order["AmazonOrderId"]).parsed
     # TODO: Need to implement nextToken for orders with a shit ton of items
-    flattened_items = flatten_items(items_res)
+    flattened_items = _flatten_items(items_res)
     print(f"{len(flattened_items)} items")
     order["OrderItems"] = flattened_items
 
 
-def flatten_items(items_res):
+def _flatten_items(items_res):
     items = items_res["OrderItems"]["OrderItem"]
     # If there's only one item, it is serialized as a dict.
     if not isinstance(items, list):
         items = [items]
     return flatten(items)
-
-
-def set_document_id(order):
-    order["_id"] = order["AmazonOrderId"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ dill==0.2.5
 future==0.16.0
 idna==2.6
 iso8601==0.1.12
-mws==0.7.4
+mws==0.8.10
 pymongo==3.6.0
 requests==2.18.4
 six==1.10.0

--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,5 @@
+"""Support making requests to MWS and massaging the returned data."""
+
 import sys
 import time
 
@@ -5,6 +7,9 @@ import iso8601
 
 
 def flatten(tree):
+    """Convert tree, replacing {"value": x} nodes with x and converting values
+    to specific types based on the key.
+    """
     if isinstance(tree, list):
         return list(map(flatten, tree))
 
@@ -24,6 +29,7 @@ def flatten(tree):
 
 
 def convert_types(key, value):
+    """Convert value to a known type based on key."""
     boolean_keys = [
         "IsReplacementOrder",
         "IsBusinessOrder",
@@ -56,6 +62,14 @@ def convert_types(key, value):
 
 
 def make_ratelimit_aware(error_cls, make_request, wait_seconds):
+    """Return a function that wraps make_request, catching error_cls and
+    retrying the request one more time after waiting wait_seconds.
+
+    error_cls -- a type of Exception to catch
+    make_request -- a function that makes a request to MWS
+    wait_seconds -- an int or float: fractional seconds to wait before retry
+    """
+
     def ratelimit_runner(*args, **kwargs):
         try:
             return make_request(*args, **kwargs)

--- a/utils.py
+++ b/utils.py
@@ -55,13 +55,13 @@ def convert_types(key, value):
     return value
 
 
-def make_ratelimit_aware(error_cls, fn, wait_seconds):
+def make_ratelimit_aware(error_cls, make_request, wait_seconds):
     def ratelimit_runner(*args, **kwargs):
         try:
-            return fn(*args, **kwargs)
+            return make_request(*args, **kwargs)
         except error_cls as err:
             print(f"error: {str(err)}", file=sys.stderr)
             time.sleep(wait_seconds)
-            return fn(*args, **kwargs)
+            return make_request(*args, **kwargs)
 
     return ratelimit_runner

--- a/utils.py
+++ b/utils.py
@@ -74,7 +74,7 @@ def make_ratelimit_aware(error_cls, make_request, wait_seconds):
         try:
             return make_request(*args, **kwargs)
         except error_cls as err:
-            print(f"error: {str(err)}", file=sys.stderr)
+            print(f"error: {err}", file=sys.stderr)
             time.sleep(wait_seconds)
             return make_request(*args, **kwargs)
 

--- a/utils.py
+++ b/utils.py
@@ -1,11 +1,11 @@
-# This file is for shared functionality between Amazon grabbing stuff
-import iso8601
 import sys
 import time
 
+import iso8601
+
 
 def flatten(tree):
-    if type(tree) is list:
+    if isinstance(tree, list):
         return list(map(flatten, tree))
 
     # If the tree is a leaf, simply return the value.
@@ -14,9 +14,9 @@ def flatten(tree):
 
     if "value" in tree:
         del tree["value"]
-    flattened = {}
 
     # If the tree has children, recurse.
+    flattened = {}
     for key in tree.keys():
         flattened[key] = convert_types(key, flatten(tree[key]))
 
@@ -55,12 +55,12 @@ def convert_types(key, value):
     return value
 
 
-def make_ratelimit_aware(error, wait_seconds, fn):
+def make_ratelimit_aware(error_cls, fn, wait_seconds):
     def ratelimit_runner(*args, **kwargs):
         try:
             return fn(*args, **kwargs)
-        except error:
-            print("ratelimited", file=sys.stderr)
+        except error_cls as err:
+            print(f"error: {str(err)}", file=sys.stderr)
             time.sleep(wait_seconds)
             return fn(*args, **kwargs)
 

--- a/utils.py
+++ b/utils.py
@@ -3,16 +3,17 @@ import iso8601
 import sys
 import time
 
+
 def flatten(tree):
     if type(tree) is list:
         return list(map(flatten, tree))
 
     # If the tree is a leaf, simply return the value.
-    if list(tree.keys()) == ['value']:
-        return tree['value']
+    if list(tree.keys()) == ["value"]:
+        return tree["value"]
 
-    if 'value' in tree:
-        del tree['value']
+    if "value" in tree:
+        del tree["value"]
     flattened = {}
 
     # If the tree has children, recurse.
@@ -21,31 +22,27 @@ def flatten(tree):
 
     return flattened
 
+
 def convert_types(key, value):
     boolean_keys = [
-        'IsReplacementOrder',
-        'IsBusinessOrder',
-        'IsPremiumOrder',
-        'IsPrime',
-        'IsGift'
+        "IsReplacementOrder",
+        "IsBusinessOrder",
+        "IsPremiumOrder",
+        "IsPrime",
+        "IsGift",
     ]
 
-    date_keys = [
-        'LatestShipDate',
-        'PurchaseDate',
-        'LastUpdateDate',
-        'EarliestShipDate'
-    ]
+    date_keys = ["LatestShipDate", "PurchaseDate", "LastUpdateDate", "EarliestShipDate"]
 
     int_keys = [
-        'NumberOfItemsShipped',
-        'NumberOfItemsUnshipped',
-        'QuantityOrdered',
-        'NumberOfItems',
-        'QuantityShipped'
+        "NumberOfItemsShipped",
+        "NumberOfItemsUnshipped",
+        "QuantityOrdered",
+        "NumberOfItems",
+        "QuantityShipped",
     ]
 
-    float_keys = ['Amount']
+    float_keys = ["Amount"]
 
     if key in boolean_keys:
         return key == "true"
@@ -57,6 +54,7 @@ def convert_types(key, value):
         return float(value)
     return value
 
+
 def make_ratelimit_aware(error, wait_seconds, fn):
     def ratelimit_runner(*args, **kwargs):
         try:
@@ -65,4 +63,5 @@ def make_ratelimit_aware(error, wait_seconds, fn):
             print("ratelimited", file=sys.stderr)
             time.sleep(wait_seconds)
             return fn(*args, **kwargs)
+
     return ratelimit_runner


### PR DESCRIPTION
This captures all of the changes that I made in order to run a recent backfill of a few days over which we'd failed to capture orders:

- Ran it through Black
- Updated the Dockerfile and requirements.txt to get it building again
- Ran it through pylint, fixed some complaints, and added more logging
- Updated the Dockerfile to support linting within the container
- Addressed the rest of the linter complaints
- Fixed a bug when `ListOrders` returns a single order
- Added an explicit delay between `ListOrderItems` requests to avoid depleting our quota
- Added support for `NextToken` on `ListOrderItems` (but I don't think we've ever needed it)
- Added support for explicit start and end dates as an alternative to `DAYS_AGO`

Apologies. I know that's a lot of changes.

Connects iFixit/ifixit#34656

CC @iFixit/bi 