### PR TITLE
Add missing guard for "NextToken" handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM base AS dev
 # Alas, black depends on regex, which doesn't have an Alpine wheel, which means
 # we need to compile it, which means we need a build environment.
 RUN apk add --no-cache --virtual .black-build-deps gcc musl-dev \
-   && pip install --prefer-binary --no-cache-dir pylint black isort \
+   && pip install --prefer-binary --no-cache-dir pylint black isort pytest \
    && apk del --no-cache .black-build-deps
 WORKDIR /
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 REPO=amazon-mws-analytics
+.PHONY: check
+check: style lint test
 
 .PHONY: build
 build:

--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,7 @@ lint: build-dev
 .PHONY: build-dev
 build-dev:
 	docker build --target dev -t $(REPO):dev .
+
+.PHONY: test
+test: build-dev
+	docker run --rm -v "$(PWD)":/app $(REPO):dev pytest app

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,14 @@ build:
 	docker build --target prod -t $(REPO):latest .
 
 .PHONY: style
-style:
-	docker build --target dev -t $(REPO):dev .
+style: build-dev
 	docker run --rm -it -v "$(PWD)":/app $(REPO):dev isort app
 	docker run --rm -it -v "$(PWD)":/app $(REPO):dev black app
 
 .PHONY: lint
-lint:
-	docker build --target dev -t $(REPO):dev .
+lint: build-dev
 	docker run --rm -it -v "$(PWD)":/app $(REPO):dev pylint app
+
+.PHONY: build-dev
+build-dev:
+	docker build --target dev -t $(REPO):dev .

--- a/orders.py
+++ b/orders.py
@@ -20,6 +20,11 @@ def generate_orders(orders_getter, orders_next_getter):
     while "NextToken" in flattened_res:
         print("Listing more orders by NextToken...", end=" ")
         orders_res = orders_next_getter(flattened_res["NextToken"]).parsed
+
+        if "Order" not in orders_res["Orders"]:
+            print("no orders")
+            return
+
         flattened_res = _flatten_orders(orders_res)
         orders = flattened_res["Orders"]["Order"]
         print(f"{len(orders)} orders")

--- a/orders_test.py
+++ b/orders_test.py
@@ -1,0 +1,37 @@
+"""Tests for orders"""
+
+from dataclasses import dataclass
+
+from .orders import generate_orders
+
+
+@dataclass
+class OrdersGetter:
+    """Fake class to represent results of running an order_getter"""
+
+    parsed: list
+
+
+def get_order_getter(orders):
+    """Get first-batch order getter"""
+    parsed = {"Orders": orders, "NextToken": {"value": "nextTok"}}
+    return lambda: OrdersGetter(parsed)
+
+
+def get_orders_next_getter(orders):
+    """Get rest-batch order getter"""
+    parsed = {"Orders": orders}
+    return lambda token: OrdersGetter(parsed)
+
+
+def test_generate_orders_with_empty_next_page():
+    """Test that a batch of orders which includes a NextToken but has no
+    orders on the next page doesn't crash the code.
+
+    """
+    orders_getter = get_order_getter({"Order": [{}, {}]})
+    # Results from next batch of orders don't even have an `Order` key:
+    orders_next_getter = get_orders_next_getter(orders={})
+    generator = generate_orders(orders_getter, orders_next_getter)
+    orders = list(generator)
+    print(orders)


### PR DESCRIPTION
We'd copy-pasted the code arount this to handle additional lists of
results when fetching from AWS. But we weren't handling the case where
we get a `NextToken` value but the next batch of results is empty. This
seems to happen when we have a number of results which is an even
multiple of 100. In that case, we'll see a `NextToken` link, fetch it,
and then crash because there's no results on it. Instead of crashing,
let's do the exact same thing we did up above if our first query found
no results.